### PR TITLE
Fix a couple cases of "unquoteBytes" missing single quotes

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -659,7 +659,7 @@ func (d *decodeState) object(v reflect.Value) {
 		start := d.off - 1
 		op = d.scanWhile(scanContinue)
 		key := d.data[start : d.off-1]
-		if key[0] == '"' {
+		if key[0] == '"' || key[0] == '\'' {
 			var ok bool
 			key, ok = unquoteBytes(key)
 			if !ok {
@@ -839,7 +839,7 @@ func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted, unq
 	if ut != nil {
 		s := item
 		if !unquotedString {
-			if item[0] != '"' {
+			if item[0] != '"' && item[0] != '\'' {
 				if fromQuoted {
 					d.saveError(fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into %v", item, v.Type()))
 				} else {


### PR DESCRIPTION
Most places `unquoteBytes` is used, it's preceded by an `if` statement verifying that `key[0]` is either `"` or `'` -- these two places were missing that second test.

I was originally testing via `json5.Unmarshal` into a type of `interface{}`, which creates the appropriate map from something like `{ 'key': 'value' }`, but when I switched from `interface{}` to an explicit `map[string]interface{}` the key stopped parsing into `"key"` and instead became `"'key'"`.  I've verified that this change fixes that, although I'm not sure exactly where to put a test for it (or whether that's necessary for this fix to be considered).  Happy to adjust/update/etc with a little guidance! :heart: