### PR TITLE
Add go 1.15 and Power Support ppc64le to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: go
+
+arch:
+  - amd64
+  - ppc64le
+
 go:
-  - 1.6.2
+  - 1.15.x
   - tip
 
 sudo: false


### PR DESCRIPTION
Updated with latest go 1.15 and added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.