### PR TITLE
Fix '\t' (byte(9)) in multiline string is invalid

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1291,7 +1291,7 @@ func unquoteBytes(s []byte) (t []byte, ok bool) {
 			}
 
 		// Quote, control characters are invalid.
-		case orig[0] == '"' && c == '"', orig[0] == '\'' && c == '\'', c < ' ':
+		case orig[0] == '"' && c == '"', orig[0] == '\'' && c == '\'', c < ' ' && c != '\t':
 			return
 
 		// ASCII

--- a/scanner.go
+++ b/scanner.go
@@ -457,6 +457,9 @@ func stateInStringDouble(s *scanner, c byte) int {
 		s.step = stateInStringEsc(stateInStringDouble)
 		return scanContinue
 	}
+	if c == '\t' {
+		return scanContinue
+	}
 	if c < 0x20 {
 		return s.error(c, "in string literal")
 	}


### PR DESCRIPTION

```go
package main

import (
	"fmt"
	"log"

	"github.com/titanous/json5"
)

type Struct struct {
	Str string
}

func main() {
	log.SetFlags(log.Lshortfile)

	var err error
	content := []byte(`{"Str":"hello\
 	abc"}`)
	var st Struct
	err = json5.Unmarshal(content, &st)
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println(st.Str)
}

// error json5.go:23: invalid character '\t' in string literal
```